### PR TITLE
Fixed Client.Shuffle() and CommandList.Shuffle()

### DIFF
--- a/mpd/client.go
+++ b/mpd/client.go
@@ -331,10 +331,10 @@ func (c *Client) Clear() error {
 // current playlist. If start or end is negative, the whole playlist is
 // shuffled.
 func (c *Client) Shuffle(start, end int) error {
-	if start > 0 && end > 0 {
-		return c.okCmd("shuffle %d:%d", start, end)
+	if start < 0 || end < 0 {
+		return c.okCmd("shuffle")
 	}
-	return c.okCmd("shuffle")
+	return c.okCmd("shuffle %d:%d", start, end)
 }
 
 // Database related commands

--- a/mpd/commandlist.go
+++ b/mpd/commandlist.go
@@ -227,10 +227,10 @@ func (cl *CommandList) Clear() {
 // current playlist. If start or end is negative, the whole playlist is
 // shuffled.
 func (cl *CommandList) Shuffle(start, end int) {
-	if start > 0 && end > 0 {
-		cl.cmdQ.PushBack(&command{fmt.Sprintf("shuffe %d:%d", start, end), nil, cmd_no_return})
+	if start < 0 || end < 0 {
+		cl.cmdQ.PushBack(&command{"shuffle", nil, cmd_no_return})
 	}
-	cl.cmdQ.PushBack(&command{"shuffle", nil, cmd_no_return})
+	cl.cmdQ.PushBack(&command{fmt.Sprintf("shuffe %d:%d", start, end), nil, cmd_no_return})
 }
 
 // End executes the command list.


### PR DESCRIPTION
There was a logic error in the Shuffle() methods. 0 is a valid value for `start` and `end`. Sorry for that.
