### PR TITLE
Added `Client.Move`

### DIFF
--- a/mpd/client.go
+++ b/mpd/client.go
@@ -473,9 +473,7 @@ func (c *Client) ListAllInfo(uri string) ([]Attrs, error) {
 	c.text.StartResponse(id)
 	defer c.text.EndResponse(id)
 
-	//return c.readAttrsList("file")
-
-	attrs = []Attrs{}
+	attrs := []Attrs{}
 	for {
 		line, err := c.text.ReadLine()
 		if err != nil {


### PR DESCRIPTION
Because MoveId only works if you know the ID of the song, and isn't based on the current location of a song in the current playlist, but the initial location of the song in the playlist.

If you only know the current state of the playlist, `Move` works better than `MoveId`.
