### PR TITLE
Extending Watcher to be able to reuse its connection

### DIFF
--- a/mpd/watcher.go
+++ b/mpd/watcher.go
@@ -5,10 +5,10 @@
 package mpd
 
 // Function to build Event to be pushed to public channel
-type EventBuilder func(subsystem string, conn *Client) interface{}
+type EventBuilder func(subsystem string, conn *Client) (interface{}, error)
 
-func subsystemNameEvent(subsystem string, conn *Client) interface{} {
-	return subsystem
+func subsystemNameEvent(subsystem string, conn *Client) (interface{}, error) {
+	return subsystem, nil
 }
 
 // Watcher represents a MPD client connection that can be watched for events.
@@ -74,7 +74,11 @@ func (w *Watcher) watch(names ...string) {
 			w.Error <- err
 		default:
 			for _, name := range changed {
-				w.Event <- w.eventBuilder(name, w.conn)
+				event, err := w.eventBuilder(name, w.conn)
+				if err != nil {
+					w.Error <- err
+				}
+				w.Event <- event
 			}
 		}
 		select {

--- a/mpd/watcher.go
+++ b/mpd/watcher.go
@@ -77,8 +77,9 @@ func (w *Watcher) watch(names ...string) {
 				event, err := w.eventBuilder(name, w.conn)
 				if err != nil {
 					w.Error <- err
+				} else {
+					w.Event <- event
 				}
-				w.Event <- event
 			}
 		}
 		select {


### PR DESCRIPTION
It is typical to get some info from MPD only in response to some event that occurs in MPD.
For instance, I want to notify a client about song change, so I create a `Watcher`, and when I get reply to `idle` request, I ask mpd about status and current song.

To achieve this now, I need to obtain 2 connections to mpd: one from `Watcher`, another from a simple `Client`.

There is no issue with the `Watcher`. `Client` though gets disconnected after some timeout, so one needs to bother with keeping connection alive. Thus, such simple task become more complicated then it should.

All this would be much simpler, if there was a way to reuse `Watcher` connection.

My solution to this is to make `Watcher` to provide untyped events instead of name of subsystem.

My code works for me, but errors are not handled yet. I can improve that if you decide, that it might be worth to merge the feature. I'm open to any comments and suggestions.

And thanks for a great lib.
