### PR TITLE
Add sticker support

### DIFF
--- a/mpd/client.go
+++ b/mpd/client.go
@@ -726,12 +726,12 @@ func (c *Client) PlaylistSave(name string) error {
 }
 
 // StickerSet applies a sticker to a song
-func (c *Client) StickerSet(song string, stickerName string, value string) error {
+func (c *Client) StickerSongSet(song string, stickerName string, value string) error {
 	return c.okCmd("sticker set song %s %s %s", quote(song), quote(stickerName), quote(value))
 }
 
-// StickerGet fetches a sticker value for a song
-func (c *Client) StickerGet(song string, stickerName string) (string, error) {
+// StickerGet fetches a sticker value for a song.
+func (c *Client) StickerSongGet(song string, stickerName string) (string, error) {
 	id, err := c.cmd("sticker get song %s %s", quote(song), quote(stickerName))
 	if err != nil {
 		return "", err
@@ -747,7 +747,7 @@ func (c *Client) StickerGet(song string, stickerName string) (string, error) {
 		return "", errors.New("No stickers in response")
 	}
 	if len(list) > 1 {
-		return "", errors.New("Multiple stickers in response: " + fmt.Sprintf("%+v", list))
+		return "", fmt.Errorf("Multiple stickers in response: %+v", list)
 	}
 	parts := strings.Split(list[0], "=")
 	if parts[0] == stickerName {

--- a/mpd/client.go
+++ b/mpd/client.go
@@ -724,3 +724,34 @@ func (c *Client) PlaylistRemove(name string) error {
 func (c *Client) PlaylistSave(name string) error {
 	return c.okCmd("save %s", quote(name))
 }
+
+// StickerSet applies a sticker to a song
+func (c *Client) StickerSet(song string, stickerName string, value string) error {
+	return c.okCmd("sticker set song %s %s %s", quote(song), quote(stickerName), quote(value))
+}
+
+// StickerGet fetches a sticker value for a song
+func (c *Client) StickerGet(song string, stickerName string) (string, error) {
+	id, err := c.cmd("sticker get song %s %s", quote(song), quote(stickerName))
+	if err != nil {
+		return "", err
+	}
+	c.text.StartResponse(id)
+	defer c.text.EndResponse(id)
+
+	list, err := c.readList("sticker")
+	if err != nil {
+		return "", err
+	}
+	if len(list) == 0 {
+		return "", errors.New("No stickers in response")
+	}
+	if len(list) > 1 {
+		return "", errors.New("Multiple stickers in response: " + fmt.Sprintf("%+v", list))
+	}
+	parts := strings.Split(list[0], "=")
+	if parts[0] == stickerName {
+		return parts[1], nil
+	}
+	return "", errors.New("Incorrect sticker response format: " + list[0])
+}

--- a/mpd/client_test.go
+++ b/mpd/client_test.go
@@ -414,13 +414,13 @@ func TestStickers(t *testing.T) {
 		{"mpd client sticker test 1", "mpd client sticker value 1"},
 		{"mpd client sticker test 2", "mpd client sticker value 2"},
 	} {
-		err = cli.StickerSet(fileName, sticker.name, sticker.value)
+		err = cli.StickerSongSet(fileName, sticker.name, sticker.value)
 		if err != nil {
 			t.Errorf("Client.StickerSet failed: '%s'\n", err)
 			return
 		}
 		time.Sleep(time.Second)
-		actualValue, err := cli.StickerGet(fileName, sticker.name)
+		actualValue, err := cli.StickerSongGet(fileName, sticker.name)
 		if err != nil {
 			t.Errorf("Client.StickerGet failed: '%s'\n", err)
 			return

--- a/mpd/client_test.go
+++ b/mpd/client_test.go
@@ -7,6 +7,7 @@ package mpd
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/fhs/gompd/mpd/internal/server"
 )
@@ -392,6 +393,45 @@ func TestQuote(t *testing.T) {
 	for _, test := range quoteTests {
 		if q := quote(test.s); q != test.q {
 			t.Errorf("quote(%s) returned %s; expected %s\n", test.s, q, test.q)
+		}
+	}
+}
+
+func TestStickers(t *testing.T) {
+	cli := localDial(t)
+	defer teardown(cli, t)
+
+	files, err := cli.GetFiles()
+	if err != nil {
+		t.Errorf("Client.GetFiles failed: %s\n", err)
+		return
+	}
+	fileName := files[0]
+	for _, sticker := range []struct {
+		name  string
+		value string
+	}{
+		{"mpd client sticker test 1", "mpd client sticker value 1"},
+		{"mpd client sticker test 2", "mpd client sticker value 2"},
+	} {
+		err = cli.StickerSet(fileName, sticker.name, sticker.value)
+		if err != nil {
+			t.Errorf("Client.StickerSet failed: '%s'\n", err)
+			return
+		}
+		time.Sleep(time.Second)
+		actualValue, err := cli.StickerGet(fileName, sticker.name)
+		if err != nil {
+			t.Errorf("Client.StickerGet failed: '%s'\n", err)
+			return
+		}
+		if actualValue != sticker.value {
+			t.Errorf(
+				"Expected sticker value returned as '%s' for '%s' but was '%s'",
+				sticker.value,
+				fileName,
+				actualValue,
+			)
 		}
 	}
 }

--- a/mpd/internal/server/server.go
+++ b/mpd/internal/server/server.go
@@ -99,11 +99,16 @@ func (p *playlist) Append(q *playlist) {
 	}
 }
 
+type stickerKey string
+type stickerValue string
+type stickers map[stickerKey]stickerValue
+
 type server struct {
 	state           string
 	database        []Attrs        // database of songs
 	index           map[string]int // maps URI to database index
 	playlists       map[string]*playlist
+	stickers        map[string]stickers
 	currentPlaylist *playlist
 	pos             int // in currentPlaylist
 	idleEventc      chan string
@@ -117,6 +122,7 @@ func newServer() *server {
 		database:        make([]Attrs, 100),
 		index:           make(map[string]int, 100),
 		playlists:       make(map[string]*playlist),
+		stickers:        make(map[string]stickers),
 		currentPlaylist: newPlaylist(),
 		pos:             0,
 		idleEventc:      make(chan string),
@@ -411,6 +417,33 @@ func (s *server) writeResponse(p *textproto.Conn, args []string, okLine string) 
 		p.PrintfLine("outputenabled: 0")
 		p.PrintfLine("outputname: upstairs")
 	case "disableoutput", "enableoutput":
+	case "sticker":
+		if len(args) < 5 {
+			ack("wrong number of arguments")
+			return
+		}
+		file := args[3]
+		key := stickerKey(args[4])
+
+		sm, ok := s.stickers[file]
+		if !ok {
+			sm = make(stickers)
+			s.stickers[file] = sm
+		}
+		if args[1] == "get" {
+			value, ok := sm[key]
+			if !ok {
+				ack("{sticker} no such sticker")
+			} else {
+				p.PrintfLine("sticker: %s=%s", key, value)
+			}
+		} else if args[1] == "set" {
+			val := stickerValue(args[5])
+			sm[key] = val
+		} else {
+			ack("Unknown sticker command " + args[1])
+			return
+		}
 	default:
 		p.PrintfLine("ACK {} unknown command %q", args[0])
 		log.Printf("unknown command: %s\n", args[0])
@@ -577,6 +610,7 @@ var knownSubsystems = []string{
 	"mixer",
 	"output",
 	"options",
+	"sticker",
 }
 
 func indexID(v []uint, id uint) int {


### PR DESCRIPTION
This is a rebase of @DanielHeath's patch with some things changed (b0138bf).

In his last comment in #17, Daniel recommends letting a query for an unset sticker to not return an error. I've omitted this change because I believe returning that error follows MPD's convention (or at least the bundled implementation) and allows one to distinguish between zero-length and unset stickers.