### PR TITLE
Fix parsing stickers with values containing '='

### DIFF
--- a/mpd/client.go
+++ b/mpd/client.go
@@ -652,7 +652,7 @@ func newSticker(name, value string) *Sticker {
 }
 
 func parseSticker(s string) (*Sticker, error) {
-	i := strings.LastIndex(s, "=")
+	i := strings.Index(s, "=")
 	if i < 0 {
 		return nil, textproto.ProtocolError("parsing sticker failed")
 	}


### PR DESCRIPTION
I'm using stickers to store binary data as base64, which has `=` as a padding character.

With the new Sticker functions, these padding characters are interpreted as the key/value separator used by MPD.

This causes my program to read sticker names like this:
```
...
image-19
image-20
image-21
image-22
image-23=Ghh8L2e<snip>f/2Q=
```

This fix makes the MPD client look for the first `=` character instead.