### PR TITLE
Fixed encoded URL bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # VIM
 *.swp
 *.swo
+.idea

--- a/mpd/client.go
+++ b/mpd/client.go
@@ -93,7 +93,11 @@ func (c *Client) cmd(format string, args ...interface{}) (uint, error) {
 }
 
 func (c *Client) printfLine(format string, args ...interface{}) error {
-	fmt.Fprintf(c.text.W, format, args...)
+	if len(args) == 0 {
+		fmt.Fprint(c.text.W, format)
+	} else {
+		fmt.Fprintf(c.text.W, format, args...)
+	}
 	c.text.W.WriteByte('\n')
 	return c.text.W.Flush()
 }

--- a/mpd/response.go
+++ b/mpd/response.go
@@ -23,9 +23,13 @@ func (c *Client) Command(format string, args ...interface{}) *Command {
 			args[i] = quote(s)
 		}
 	}
+	cmd := fmt.Sprintf(format, args...)
+	if len(args) == 0 {
+		cmd = format
+	}
 	return &Command{
 		client: c,
-		cmd:    fmt.Sprintf(format, args...),
+		cmd:    cmd,
 	}
 }
 


### PR DESCRIPTION
Following code reproduces the bug.

```go
package main

import (
    "github.com/fhs/gompd/mpd"
    "log"
)


func main() {
        conn, err := mpd.Dial("tcp", "localhost:6600")
        if err != nil {
                log.Fatalln(err)
        }
        defer conn.Close()

        conn.Clear()
        conn.Add("http://localhost/music/AC_DC/Back%20In%20Black/Hells%20Bells.mp3")
        conn.Play(0)
}
```