### PR TITLE
Escape the percent sign to make it literal when quoting command arguments

### DIFF
--- a/mpd/client.go
+++ b/mpd/client.go
@@ -22,10 +22,16 @@ func quote(s string) string {
 	i := 0
 	q[i], i = '"', i+1
 	for _, c := range []byte(s) {
-		if c == '"' {
+		switch c {
+		case '"':
 			q[i], i = '\\', i+1
 			q[i], i = '"', i+1
-		} else {
+		case '%':
+			// Note: the quoted string will be used as format string in cmd()
+			// → escape the percent sign to make it literal
+			q[i], i = '%', i+1
+			q[i], i = '%', i+1
+		default:
 			q[i], i = c, i+1
 		}
 	}

--- a/mpd/client_test.go
+++ b/mpd/client_test.go
@@ -463,6 +463,8 @@ var quoteTests = []struct {
 	{`test.ogg`, `"test.ogg"`},
 	{`test "song".ogg`, `"test \"song\".ogg"`},
 	{`04 - ILL - DECAYED LOVE　feat.℃iel.ogg`, `"04 - ILL - DECAYED LOVE　feat.℃iel.ogg"`},
+	{`95%.mp3`, `"95%%.mp3"`},
+	{`%d95%s.mp3`, `"%%d95%%s.mp3"`},
 }
 
 func TestQuote(t *testing.T) {


### PR DESCRIPTION
I noticed that searching for something with a % always yielded an error with MPD complaining about a missing space after the closing double quote.  Traced it down to MPD receiving something containing "(MISSING)".

Here's a short program to show the behavior:

```
package main
import "github.com/fhs/gompd/mpd"

func main() {
  c, err := mpd.Dial("tcp", "localhost:6601")
  if err != nil {
    panic(err)
  }
  _, err = c.Search("any", "95%")
  if err != nil {
    panic(err)
  }
}
```

Before running the program I started netcat and got the following result:

```
nc -l 6601 <<< "OK MPD Test"
search "any" "95%!!(MISSING)"(MISSING)
```

Traced it down to cmd() calling printfLine with the command as format string.  This pull request is the proposed fix.