### PR TITLE
Fixed URL escape issue

### DIFF
--- a/mpd/response.go
+++ b/mpd/response.go
@@ -42,7 +42,7 @@ func (cmd *Command) String() string {
 
 // OK sends command to server and checks for error.
 func (cmd *Command) OK() error {
-	id, err := cmd.client.cmd(cmd.cmd)
+	id, err := cmd.client.cmd("%v", cmd.cmd)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I encountered this issue myself and found #42, which was unresolved. Changing this fixed the error, but I am not familiar enough with the code to know if this is the only place where URLs can be expected. I am also not sure how to easily test this change in a unit test, since what we want to check is if our URL was formatted correctly.