### PR TITLE
Reimplement quoting as explained in #55

### DIFF
--- a/mpd/client.go
+++ b/mpd/client.go
@@ -16,25 +16,19 @@ import (
 	"time"
 )
 
-// Quote quotes strings in the format understood by MPD.
+// Quote quotes string VALUES in the format understood by MPD.
 // See: https://github.com/MusicPlayerDaemon/MPD/blob/master/src/util/Tokenizer.cxx
-// NB1: double quotes inside double-quoted literals must be escaped by the caller.
-// NB2: this will probably fail should you need to use single quotes outside of double-quoted literal.
+// NB: this function shouldn't be used on the PROTOCOL LEVEL because it considers single quotes special chars and
+// escapes them.
 func quote(s string) string {
 	q := make([]byte, 2+2*len(s))
 	i := 0
 	q[i], i = '"', i+1
 	for _, c := range []byte(s) {
-		// We need to quote single/double quotes and backslash
+		// We need to escape single/double quotes and a backslash by prepending them with a '\'
 		if c == '"' || c == '\\' || c == '\'' {
-			// Prepend the char with a backslash
 			q[i] = '\\'
 			i++
-			// For single quotes the backslash must be doubled
-			if c == '\'' {
-				q[i] = '\\'
-				i++
-			}
 		}
 		q[i] = c
 		i++

--- a/mpd/client_test.go
+++ b/mpd/client_test.go
@@ -478,13 +478,14 @@ func TestQuote(t *testing.T) {
 	}{
 		{`test.ogg`, `"test.ogg"`},
 		{`test "song".ogg`, `"test \"song\".ogg"`},
-		{`test with 'single' and "double" quotes`, `"test with \\'single\\' and \"double\" quotes"`},
+		{`test with 'single' and "double" quotes`, `"test with \'single\' and \"double\" quotes"`},
+		{`escape \"escaped\"`, `"escape \\\"escaped\\\""`},
+		{`just a \`, `"just a \\"`},
 		{`04 - ILL - DECAYED LOVE　feat.℃iel.ogg`, `"04 - ILL - DECAYED LOVE　feat.℃iel.ogg"`},
 		// Test case provided at https://www.musicpd.org/doc/html/protocol.html#escaping-string-values.
-		// NB: it deviates from the original case in that the single quote is left unescaped because the escaping is
-		// done by quote(). With this approach, the user should only take care of backslash-escaping double quotes
-		// inside a double-quoted literal.
-		{`(Artist == "foo'bar\"")`, `"(Artist == \"foo\\'bar\\\"\")"`},
+		// NB: we don't support quoting in the "protocol level" mode, hence single quotes get the same treatment as
+		// double quotes and there are 3 backslashes before the single quote, too.
+		{`(Artist == "foo\'bar\"")`, `"(Artist == \"foo\\\'bar\\\"\")"`},
 	}
 	// Run tests
 	for _, test := range quoteTests {
@@ -495,8 +496,8 @@ func TestQuote(t *testing.T) {
 }
 
 func TestQuoteArgs(t *testing.T) {
-	input := []string{`Artist`, `Nightingale`, `Title`, `\"Don't Go Away\"`}
-	expected := `"Artist" "Nightingale" "Title" "\\\"Don\\'t Go Away\\\""`
+	input := []string{`Artist`, `Nightingale`, `Title`, `"Don't Go Away"`}
+	expected := `"Artist" "Nightingale" "Title" "\"Don\'t Go Away\""`
 	if got := quoteArgs(input); got != expected {
 		t.Errorf("quoteArgs(%v) returned %s; expected %s", input, got, expected)
 	}


### PR DESCRIPTION
Single quotes do get escaped properly, but quoting on the "protocol level" is not implemented