### PR TITLE
Added Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go_import_path: github.com/fhs/gompd
-
+arch:
+ - amd64
+ - ppc64le
 script:
  - go install -v ./...
  - test `gofmt -l . | wc -l` = 0


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.