### PR TITLE
Fix `go test -count n`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.18.x, 1.19.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
@@ -13,10 +13,15 @@ jobs:
       GO111MODULE: on
 
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
+        check-latest: true
+        cache: true
 
     - name: Go environment
       run: |
@@ -25,11 +30,8 @@ jobs:
         echo PATH is $PATH
       shell: bash
 
-    - name: Checkout code
-      uses: actions/checkout@v2
-
     - name: Run tests
-      run: go test -race -v ./...
+      run: go test -race -v -count=2 ./...
 
     - name: Check gofmt
       run: |

--- a/mpd/client_test.go
+++ b/mpd/client_test.go
@@ -98,6 +98,7 @@ func localDial(t *testing.T) *Client {
 }
 
 func teardown(cli *Client, t *testing.T) {
+	cli.Clear()
 	if err := cli.Close(); err != nil {
 		t.Errorf("Client.Close() = %s need nil", err)
 	}


### PR DESCRIPTION
Calls client.Clear the client's playlist on teardown, for the next iteration to have
a clean state.

```
$ go test -count 2 ./...
--- FAIL: TestPlaylistInfo (0.00s)
    client_test.go:98: Client.PlaylistInfo(-1, -1) len = 5 need 4
FAIL
FAIL	github.com/fhs/gompd/v2/mpd	0.039s
?   	github.com/fhs/gompd/v2/mpd/internal/server	[no test files]
FAIL
```
