### PR TITLE
Optimize the size of some struct

### DIFF
--- a/mpd/client.go
+++ b/mpd/client.go
@@ -61,10 +61,10 @@ type Client struct {
 // It contains the error number, the index of the causing command in the command list,
 // the name of the command in the command list and the error message.
 type Error struct {
-	Code             ErrorCode
-	CommandListIndex int
 	CommandName      string
 	Message          string
+	CommandListIndex int
+	Code             ErrorCode
 }
 
 // ErrorCode is the error code of a Error.

--- a/mpd/internal/server/server.go
+++ b/mpd/internal/server/server.go
@@ -162,17 +162,17 @@ func (ss stickers) Sorted() []*sticker {
 }
 
 type server struct {
-	state           string
-	database        []attrs        // database of songs
 	index           map[string]int // maps URI to database index
 	playlists       map[string]*playlist
 	currentPlaylist *playlist
 	songStickers    map[string]stickers
-	pos             int // in currentPlaylist
-	artwork         []byte
 	idleEventc      chan string
 	idleStartc      chan *idleRequest
 	idleEndc        chan uint
+	state           string
+	database        []attrs // database of songs
+	artwork         []byte
+	pos             int // in currentPlaylist
 }
 
 func newServer() *server {
@@ -758,9 +758,9 @@ const (
 )
 
 type request struct {
-	typ     requestType
 	args    []string
 	cmdList [][]string
+	typ     requestType
 }
 
 func (s *server) readRequest(p *textproto.Conn) (*request, error) {


### PR DESCRIPTION
Moving these fields makes the struct smaller, because of padding space. This is probably better and doesn't hurt.

Actually there is more struct that can be optimized in https://github.com/fhs/gompd/blob/master/mpd/commandlist.go, but that is dealt with as a side effect of #81.